### PR TITLE
chore: add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,17 +6,20 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build, Test, Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
         with:
           go-version-file: go.mod
           cache: true
@@ -31,6 +34,6 @@ jobs:
         run: go vet ./...
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
         with:
-          version: latest
+          version: v2.11.4


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml` — triggers on push/PR to main
- Steps: checkout → setup-go (go-version-file: go.mod) → build → test → vet → golangci-lint
- All action SHAs pinned (supply chain hardening)
- golangci-lint pinned to `v2.11.4` via `golangci/golangci-lint-action@v9.2.0`
- `permissions: contents: read` (least-privilege GITHUB_TOKEN)
- Runner pinned to `ubuntu-24.04`

## Test plan

- [x] `go build ./...` passes on stub codebase
- [x] `go test ./...` passes (reports `[no test files]`, not error)
- [x] `go vet ./...` clean
- [x] YAML syntax valid
- [x] golangci-lint version explicitly pinned (acceptance criterion)
- [x] Go version derived from `go.mod` via `go-version-file`

Closes #13