### PR TITLE
chore: add Dockerfile and Makefile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# Version control
+.git
+.github
+
+# Claude Code tooling — not needed in image
+.claude
+
+# Environment files — never bake secrets into images
+.env
+.env.*
+!.env.local.example
+
+# Private key material (future phases)
+*.pem
+*.key
+*.p8
+
+# Test data and docs — not part of the binary
+tests/
+schemas/
+docs/
+*.md
+!README.md
+
+# Build artifacts
+*.out
+coverage.*
+
+# Editor / IDE
+.idea/
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM golang:1.24-bookworm AS builder
+FROM golang:1.24-bookworm@sha256:1a6d4452c65dea36aac2e2d606b01b4a029ec90cc1ae53890540ce6173ea77ac AS builder  # 1.24-bookworm
 
 WORKDIR /src
 
@@ -12,9 +12,11 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /gateway ./cmd/gateway
 
 # Stage 2: Runtime — distroless contains only the binary, no shell or toolchain.
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static@sha256:e3f945647ffb95b5839c07038d64f9811adf17308b9121d8a2b87b6a22a80a39  # static:nonroot
 
 COPY --from=builder /gateway /gateway
 
 USER nonroot:nonroot
+# Run with: docker run --read-only --tmpfs /tmp aga2aga
+# Kubernetes: securityContext.readOnlyRootFilesystem: true, allowPrivilegeEscalation: false
 ENTRYPOINT ["/gateway"]

--- a/Makefile
+++ b/Makefile
@@ -19,19 +19,24 @@ test:
 ## lint: run go vet and golangci-lint
 lint:
 	go vet ./...
+	@command -v golangci-lint >/dev/null 2>&1 || \
+		{ echo "golangci-lint not installed — see https://golangci-lint.run/usage/install/"; exit 1; }
 	golangci-lint run
 
 ## validate: validate test fixtures with the aga CLI (no-op until Phase 1)
 validate:
-	@if ls tests/testdata/*.md 2>/dev/null | grep -q .; then \
-		go run ./cmd/aga validate tests/testdata/*.md; \
+	@files=$$(find tests/testdata -maxdepth 1 -name '*.md' 2>/dev/null); \
+	if [ -n "$$files" ]; then \
+		echo "$$files" | xargs go run ./cmd/aga validate; \
 	else \
 		echo "No fixtures found in tests/testdata/ — skipping"; \
 	fi
 
-## docker: build the gateway container image
+VERSION ?= $(shell git rev-parse --short HEAD)
+
+## docker: build the gateway container image (tagged with git SHA and :latest)
 docker:
-	docker build -t aga2aga .
+	docker build -t aga2aga:$(VERSION) -t aga2aga:latest .
 
 ## tidy: sync go.mod and go.sum
 tidy:


### PR DESCRIPTION
## Summary

- `Dockerfile` — multi-stage: `golang:1.24-bookworm` builder → `gcr.io/distroless/static:nonroot` runtime; both FROM lines SHA-pinned; `CGO_ENABLED=0 GOOS=linux -trimpath -ldflags="-s -w"`; runs as `nonroot:nonroot`
- `Makefile` — targets: `help` (default), `build`, `test`, `lint`, `validate`, `docker`, `tidy`; `docker` target tags with git SHA + `:latest`; `validate` uses `find+xargs` (no glob injection); `golangci-lint` not-installed check
- `.dockerignore` — excludes `.git`, `.claude`, `.env.*`, `*.pem/key`, `tests/`, `docs/` from build context

## Test plan

- [x] `make build` — `go build ./...` passes
- [x] `make test` — passes (no test files yet)
- [x] `make validate` — no-op with clear message
- [x] `make tidy` — idempotent
- [x] `make help` — prints all targets
- [x] `go vet ./...` clean

Closes #14