### PR TITLE
chore: adapt fix-review and ship skills for PR-required main branch

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -100,15 +100,20 @@ The skill runs 3 external model rounds + Claude Arbiter, then auto-merges.
 
 ### 8. Post-Merge Cleanup
 
-After merge, remove the in-progress label:
+The fix-review skill queues auto-merge and waits for the PR to reach MERGED state. Once fix-review confirms the merge, remove the label and return to main:
+
 ```bash
 gh issue edit {number} --repo valpere/aga2aga --remove-label "status: in-progress"
+git checkout main && git pull
 ```
+
+If fix-review timed out waiting for merge, check `gh pr view {pr-number} --json state` before removing the label.
 
 ---
 
 ## Rules
 
+- Never push directly to main — `main` requires a PR; use feature branches
 - Never skip the TDD cycle — tests MUST fail before implementation
 - Never skip parallel review — all three agents must run
 - Never merge without fix-review — even if parallel review finds nothing

--- a/.claude/skills/fix-review/SKILL.md
+++ b/.claude/skills/fix-review/SKILL.md
@@ -227,25 +227,44 @@ Post collapsible PR comment if enabled.
 
 ## STEP 9: Auto-merge
 
+The `main` branch requires a PR (ruleset "prs"). Auto-merge is enabled on the repo, so `--auto` queues the merge and GitHub completes it once all required checks pass.
+
 ```bash
 gh pr merge {number} --auto --merge
 ```
 
-`--auto` waits for required CI checks. Resolve conflicts first — `--auto` does not handle them.
+Resolve conflicts before this step — `--auto` does not handle them.
 
-Print final summary table: fixed / escalated / dismissed / deferred / skipped.
+**Wait for merge to complete** (poll, 5-minute timeout):
+```bash
+for i in $(seq 1 60); do
+  STATE=$(gh pr view {number} --repo valpere/aga2aga --json state --jq '.state')
+  [ "$STATE" = "MERGED" ] && break
+  echo "Waiting for merge... ($((i * 5))s)"
+  sleep 5
+done
+STATE=$(gh pr view {number} --repo valpere/aga2aga --json state --jq '.state')
+[ "$STATE" != "MERGED" ] && echo "WARNING: PR not yet merged after 5 minutes — check GitHub Actions"
+```
+
+After confirmed merge, pull main and print final summary table: fixed / escalated / dismissed / deferred / skipped.
+
+```bash
+git checkout main && git pull
+```
 
 ---
 
 ## RULES
 
 1. **Never force-push** — regular `git push` only
-2. **Never modify test files** to make tests pass — fix source code
-3. **Never touch unrelated code** — only files in review comments or Arbiter findings
-4. **4 rounds maximum** — hard stop
-5. **DO_NOT_TOUCH conflicts** — skip and surface to user
-6. **One commit per round** — batch all fixes
-7. **Tests must pass before pushing** — revert breaking fix, continue
-8. **JSON parse failure** — retry once, skip reviewer on second failure
-9. **Provider switch is permanent** — `sed` into config.yaml immediately
-10. **Arbiter always runs** — even if all 3 model rounds stop early
+2. **Never push directly to main** — `main` requires a PR; all commits go on feature branches and merge via `gh pr merge`
+3. **Never modify test files** to make tests pass — fix source code
+4. **Never touch unrelated code** — only files in review comments or Arbiter findings
+5. **4 rounds maximum** — hard stop
+6. **DO_NOT_TOUCH conflicts** — skip and surface to user
+7. **One commit per round** — batch all fixes
+8. **Tests must pass before pushing** — revert breaking fix, continue
+9. **JSON parse failure** — retry once, skip reviewer on second failure
+10. **Provider switch is permanent** — `sed` into config.yaml immediately
+11. **Arbiter always runs** — even if all 3 model rounds stop early


### PR DESCRIPTION
## Summary

- Enabled `allow_auto_merge` on the repo (required for `gh pr merge --auto` to work)
- `fix-review` Step 9: add 5-minute poll loop waiting for `MERGED` state after `--auto` queue; add `git checkout main && git pull` after confirmed merge
- `fix-review` RULES: add rule "Never push directly to main"
- `ship` Step 8: clarify cleanup runs after fix-review confirms MERGED; add fallback instruction
- `ship` RULES: add "Never push directly to main" as first rule

## Context

GitHub ruleset "prs" (id 14273512) now requires all changes to `main` to go through a PR. Direct pushes are blocked. The workflow already created PRs for all merges, so no implementation changes — only the merge/cleanup steps in the skills needed adapting.

## Test plan

- [x] `gh pr merge --auto` now works (allow_auto_merge enabled)
- [x] Ruleset confirmed: no bypass actors, PR required for default branch
- [x] Skills updated to poll for MERGED state before cleanup