### PR TITLE
security: harden Envelope, As[T], and Extra against injection

### DIFF
--- a/pkg/document/types.go
+++ b/pkg/document/types.go
@@ -43,20 +43,28 @@ func (s *StringOrList) UnmarshalYAML(value *yaml.Node) error {
 }
 
 // Envelope holds the standard wire fields present in every Skills Document header.
+//
+// SECURITY: The From field is self-reported and cryptographically unverified until
+// Phase 3 (Ed25519 signatures via pkg/identity). Authorization decisions MUST NOT
+// be based on From alone. Use the Signature + SigningKeyID fields once pkg/identity
+// is implemented.
 type Envelope struct {
-	Type         protocol.MessageType `yaml:"type"`
-	Version      string               `yaml:"version"`
-	ID           string               `yaml:"id,omitempty"`
-	From         string               `yaml:"from,omitempty"`
-	To           StringOrList         `yaml:"to,omitempty"`
-	CreatedAt    string               `yaml:"created_at,omitempty"`
-	InReplyTo    string               `yaml:"in_reply_to,omitempty"`
-	ThreadID     string               `yaml:"thread_id,omitempty"`
-	ExecID       string               `yaml:"exec_id,omitempty"`
-	TTL          string               `yaml:"ttl,omitempty"`
-	Status       string               `yaml:"status,omitempty"`
-	Signature    string               `yaml:"signature,omitempty"`
-	SigningKeyID string               `yaml:"signing_key_id,omitempty"`
+	Type    protocol.MessageType `yaml:"type"`
+	Version string               `yaml:"version"`
+	ID      string               `yaml:"id,omitempty"`
+	// WARNING: unverified until Phase 3 — see struct doc above.
+	From      string       `yaml:"from,omitempty"`
+	To        StringOrList `yaml:"to,omitempty"`
+	// DO_NOT_TOUCH (for agent.genome documents): spec §5.4 — created_at is
+	// immutable once set. See AgentGenome for the full immutability contract.
+	CreatedAt    string `yaml:"created_at,omitempty"`
+	InReplyTo    string `yaml:"in_reply_to,omitempty"`
+	ThreadID     string `yaml:"thread_id,omitempty"`
+	ExecID       string `yaml:"exec_id,omitempty"`
+	TTL          string `yaml:"ttl,omitempty"`
+	Status       string `yaml:"status,omitempty"`
+	Signature    string `yaml:"signature,omitempty"`
+	SigningKeyID string `yaml:"signing_key_id,omitempty"`
 }
 
 // Document is a parsed Skills Document: a structured envelope plus the
@@ -65,6 +73,11 @@ type Document struct {
 	Envelope `yaml:",inline"`
 	// Extra captures all YAML fields not defined in Envelope.
 	// Used by As[T] to unmarshal type-specific structs.
+	//
+	// SECURITY: Extra MUST NOT be used directly for signing, signature
+	// verification, lifecycle state transitions, or authorization decisions.
+	// Always go through As[T] to obtain a typed struct.
+	// Keys in Extra are unvalidated and attacker-controlled.
 	Extra map[string]any `yaml:",inline"`
 	// Body is the Markdown content after the YAML front matter. Not marshalled.
 	Body string `yaml:"-"`
@@ -72,15 +85,34 @@ type Document struct {
 	Raw []byte `yaml:"-"`
 }
 
+// envelopeKeys is the set of yaml tag names claimed by Envelope.
+// As[T] strips these from doc.Extra before the marshal round-trip so that
+// attacker-controlled Extra values can never shadow Envelope fields in T.
+var envelopeKeys = map[string]struct{}{ //nolint:gochecknoglobals
+	"type": {}, "version": {}, "id": {}, "from": {}, "to": {},
+	"created_at": {}, "in_reply_to": {}, "thread_id": {}, "exec_id": {},
+	"ttl": {}, "status": {}, "signature": {}, "signing_key_id": {},
+}
+
 // As converts doc.Extra into a typed struct T via a YAML round-trip.
 // The round-trip ensures that all yaml tags on T are respected.
+// Envelope keys are stripped from doc.Extra before marshalling so they
+// cannot bleed into T even if Extra was manipulated directly.
 // Returns an error if doc is nil.
 func As[T any](doc *Document) (*T, error) {
 	if doc == nil {
 		return nil, fmt.Errorf("As: doc is nil")
 	}
 
-	data, err := yaml.Marshal(doc.Extra)
+	filtered := make(map[string]any, len(doc.Extra))
+
+	for k, v := range doc.Extra {
+		if _, isEnvelope := envelopeKeys[k]; !isEnvelope {
+			filtered[k] = v
+		}
+	}
+
+	data, err := yaml.Marshal(filtered)
 	if err != nil {
 		return nil, fmt.Errorf("As: marshal extra: %w", err)
 	}

--- a/pkg/document/types_test.go
+++ b/pkg/document/types_test.go
@@ -71,6 +71,75 @@ func TestStringOrList_UnmarshalYAML_Error(t *testing.T) {
 	}
 }
 
+func TestStringOrList_NullBecomesEmpty(t *testing.T) {
+	t.Parallel()
+
+	// YAML null (~) must not silently route to recipient "".
+	// It must produce an empty slice.
+	input := "to: ~"
+
+	var dest struct {
+		To document.StringOrList `yaml:"to"`
+	}
+
+	if err := yaml.Unmarshal([]byte(input), &dest); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+
+	if len(dest.To) != 0 {
+		t.Errorf("YAML null should produce empty StringOrList, got %v", dest.To)
+	}
+}
+
+func TestAs_StripsEnvelopeKeys(t *testing.T) {
+	t.Parallel()
+
+	type Inner struct {
+		From    string `yaml:"from"`
+		AgentID string `yaml:"agent_id"`
+	}
+
+	// Simulate Extra that somehow contains an envelope key alongside a payload key.
+	// As[T] must strip envelope keys so they cannot bleed into typed structs.
+	doc := &document.Document{
+		Envelope: document.Envelope{
+			Type:         "",
+			Version:      "",
+			ID:           "",
+			From:         "legit-sender",
+			To:           nil,
+			CreatedAt:    "",
+			InReplyTo:    "",
+			ThreadID:     "",
+			ExecID:       "",
+			TTL:          "",
+			Status:       "",
+			Signature:    "",
+			SigningKeyID: "",
+		},
+		Extra: map[string]any{
+			"from":     "injected",
+			"agent_id": "agent-42",
+		},
+		Body: "",
+		Raw:  nil,
+	}
+
+	got, err := document.As[Inner](doc)
+	if err != nil {
+		t.Fatalf("As[Inner]() error = %v", err)
+	}
+
+	// Envelope key "from" in Extra must NOT bleed into the typed struct.
+	if got.From != "" {
+		t.Errorf("As[T] leaked envelope key into typed struct: From = %q, want empty", got.From)
+	}
+
+	if got.AgentID != "agent-42" {
+		t.Errorf("AgentID = %q, want agent-42", got.AgentID)
+	}
+}
+
 func TestAs_RoundTrip(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Security hardening based on security-reviewer findings for pkg/document (issues identified after PR #29 merged).

- **As[T] envelope key stripping**: Strips Envelope yaml tag names from `doc.Extra` before the marshal round-trip, preventing attacker-controlled Extra values from bleeding into typed structs even if Extra is manipulated directly (CWE-915)
- **Envelope.From warning**: Adds SECURITY comment documenting that `From` is self-reported and unverified until Phase 3 Ed25519 (CWE-290)
- **Envelope.CreatedAt DO_NOT_TOUCH cross-reference**: Documents genome immutability constraint at the field level, not just in AgentGenome
- **Extra security contract**: Documents that Extra must not be used directly for auth/signing/lifecycle decisions

Issue #30 filed separately for `SpawnProposal.GenomePatch map[string]any` replacement (requires more planning before any patch-apply logic is written).

## Test plan

- [x] `TestAs_StripsEnvelopeKeys`: envelope keys in Extra cannot bleed into typed structs
- [x] `TestStringOrList_NullBecomesEmpty`: yaml.v3 null → empty slice confirmed
- [x] `go test ./...` passes (all 26 tests green)
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)