### PR TITLE
fix: migrate golangci-lint config to v2 format

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -32,18 +32,18 @@ linters:
         - "^github\\.com/valpere/aga2aga/pkg/document\\.Envelope$"
         - "^github\\.com/valpere/aga2aga/pkg/document\\.Document$"
 
-issues:
-  exclude-rules:
-    # err113: dynamic errors in UnmarshalYAML are intentional — no useful sentinel value.
-    - path: "types\\.go"
-      linters: [err113]
-      text: "StringOrList"
-    # exhaustive: switch on yaml.Kind — default case already handles unknown nodes correctly.
-    - path: "types\\.go"
-      linters: [exhaustive]
-    # goconst in tests: repeated literals improve readability in fixture-heavy tests.
-    - path: "_test\\.go"
-      linters: [goconst]
-    # wrapcheck: pkg/document wraps errors from yaml.v3 with fmt.Errorf+%w, which is correct.
-    - path: "pkg/document"
-      linters: [wrapcheck]
+  exclusions:
+    rules:
+      # err113: dynamic errors in UnmarshalYAML are intentional — no useful sentinel value.
+      - path: "types\\.go"
+        linters: [err113]
+        text: "StringOrList"
+      # exhaustive: switch on yaml.Kind — default case already handles unknown nodes correctly.
+      - path: "types\\.go"
+        linters: [exhaustive]
+      # goconst in tests: repeated literals improve readability in fixture-heavy tests.
+      - path: "_test\\.go"
+        linters: [goconst]
+      # wrapcheck: pkg/document wraps errors from yaml.v3 with fmt.Errorf+%w, which is correct.
+      - path: "pkg/document"
+        linters: [wrapcheck]


### PR DESCRIPTION
## Summary

- Add `version: "2"` top-level key required by golangci-lint v2
- Rename `linters-settings` → `linters.settings` per v2 schema
- CI was failing with exit code 3 (config error) on every run since PR #31 merged

## Test plan

- [ ] CI lint step passes (no exit code 3)
- [ ] `go test ./...` passes
- [ ] `go vet ./...` clean

Fixes CI regression introduced when PR #31 merged without this config fix.