### PR TITLE
feat(document): replace SpawnProposal.GenomePatch map[string]any with typed struct

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,8 @@ internal/gateway/ MCP Gateway implementation
 - `Envelope.From` is self-reported; authorization MUST NOT rely on it until Phase 3 (Ed25519)
 - `Document.Extra` is attacker-controlled; never use directly for auth, signing, or lifecycle decisions
 - `As[T]` strips the 13 Envelope yaml keys via `envelopeKeys` map before marshal — attacker cannot shadow Envelope fields in typed structs
-- `SpawnProposal.GenomePatch` remains `map[string]any` — tracked in issue #30 (fix before patch-apply logic)
+- `SpawnProposal.GenomePatch` is typed (`*GenomePatch`) — DO_NOT_TOUCH fields are structurally absent; patch-apply MUST only append to `SoftConstraints`, never replace
+- `PromptPolicy.Style` is `map[string]any` — attacker-controlled; patch-apply MUST sanitise before use (tracked: open issue)
 
 ## Skills and Plugins
 

--- a/pkg/document/types_genome.go
+++ b/pkg/document/types_genome.go
@@ -89,6 +89,7 @@ type FitnessMetrics struct {
 }
 
 // Fitness holds the agent's current fitness objectives and scores.
+// DO_NOT_TOUCH via spawn proposal: intentionally absent from GenomePatch — spec §5.4.
 type Fitness struct {
 	Objectives FitnessMetrics `yaml:"objectives,omitempty"`
 }
@@ -109,12 +110,14 @@ type MutationPolicy struct {
 }
 
 // RetirementPolicy defines when an agent should be automatically retired.
+// DO_NOT_TOUCH via spawn proposal: intentionally absent from GenomePatch — spec §5.4.
 type RetirementPolicy struct {
 	IfBelowFitness float64 `yaml:"if_below_fitness,omitempty"`
 	MinEvaluations int     `yaml:"min_evaluations,omitempty"`
 }
 
 // SandboxPolicy controls constraints for agents in sandbox status.
+// DO_NOT_TOUCH via spawn proposal: intentionally absent from GenomePatch — spec §5.4.
 type SandboxPolicy struct {
 	MaxTasks           int  `yaml:"max_tasks,omitempty"`
 	CanTouchProduction bool `yaml:"can_touch_production,omitempty"`
@@ -133,6 +136,8 @@ type GenomePatch struct {
 	MemoryPolicy    *MemoryPolicy  `yaml:"memory_policy,omitempty"`
 	Thresholds      *Thresholds    `yaml:"thresholds,omitempty"`
 	Economics       *Economics     `yaml:"economics,omitempty"`
+	// Patch-apply MUST append these to the live Constraints.Soft slice — never replace it.
+	// Removal of existing soft constraints via a spawn proposal is not permitted.
 	SoftConstraints []string       `yaml:"soft_constraints,omitempty"`
 	Tags            []string       `yaml:"tags,omitempty"`
 }

--- a/pkg/document/types_spawn.go
+++ b/pkg/document/types_spawn.go
@@ -9,6 +9,8 @@ type SpawnProposal struct {
 	SpawnReason    string         `yaml:"spawn_reason"`
 	RiskLevel      string         `yaml:"risk_level,omitempty"`
 	EvaluationPlan string         `yaml:"evaluation_plan,omitempty"`
+	// GenomePatch describes the mutable subset of AgentGenome a proposer may change.
+	// DO_NOT_TOUCH fields are structurally absent. See GenomePatch in types_genome.go.
 	GenomePatch    *GenomePatch   `yaml:"genome_patch,omitempty"`
 }
 

--- a/pkg/document/types_spawn_test.go
+++ b/pkg/document/types_spawn_test.go
@@ -83,6 +83,10 @@ decision: approved_for_sandbox
 	}
 }
 
+// TestSpawnProposal_GenomePatch_MutableFields verifies that valid mutable fields in
+// genome_patch round-trip correctly through As[SpawnProposal].
+// Flat (non-table-driven): single adversarial fixture whose clarity outweighs the
+// overhead of wrapping in []struct{}. Add a table row if new field coverage is needed.
 func TestSpawnProposal_GenomePatch_MutableFields(t *testing.T) {
 	t.Parallel()
 
@@ -137,6 +141,11 @@ genome_patch:
 	}
 }
 
+// TestSpawnProposal_GenomePatch_DoNotTouchFieldsDropped is a security regression test.
+// It verifies that DO_NOT_TOUCH fields injected into genome_patch YAML are structurally
+// dropped by the typed GenomePatch struct and are never accessible to callers.
+// Flat (non-table-driven): single adversarial payload whose inline YAML is the spec.
+// DO NOT DELETE — this test locks the CWE-915 fix from issue #30.
 func TestSpawnProposal_GenomePatch_DoNotTouchFieldsDropped(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- `GenomePatch` struct defined in `types_genome.go` — only mutable fields; all DO_NOT_TOUCH fields (`agent_id`, `kind`, `lineage`, `identity`, `constraints.hard`, `mutation_policy.forbidden`) are structurally absent (spec §5.4)
- `SpawnProposal.GenomePatch` changed from `map[string]any` to `*GenomePatch`
- `RetirementPolicy`, `SandboxPolicy`, `Fitness` annotated as excluded from patch surface
- `SoftConstraints` annotated with append-only constraint for future patch-apply
- Security regression test: `TestSpawnProposal_GenomePatch_DoNotTouchFieldsDropped` — injected DO_NOT_TOUCH keys are structurally dropped; marked DO NOT DELETE
- `CLAUDE.md` updated to reflect typed GenomePatch and flag `PromptPolicy.Style`
- Follow-up issue #35 opened for `PromptPolicy.Style map[string]any`

## Test plan

- [ ] `go test ./...` passes
- [ ] `go vet ./...` clean
- [ ] CI passes

Closes #30