### PR TITLE
chore(document): apply gofmt alignment normalization

### DIFF
--- a/pkg/document/types.go
+++ b/pkg/document/types.go
@@ -53,8 +53,8 @@ type Envelope struct {
 	Version string               `yaml:"version"`
 	ID      string               `yaml:"id,omitempty"`
 	// WARNING: unverified until Phase 3 — see struct doc above.
-	From      string       `yaml:"from,omitempty"`
-	To        StringOrList `yaml:"to,omitempty"`
+	From string       `yaml:"from,omitempty"`
+	To   StringOrList `yaml:"to,omitempty"`
 	// DO_NOT_TOUCH (for agent.genome documents): spec §5.4 — created_at is
 	// immutable once set. See AgentGenome for the full immutability contract.
 	CreatedAt    string `yaml:"created_at,omitempty"`

--- a/pkg/document/types_genome.go
+++ b/pkg/document/types_genome.go
@@ -131,9 +131,9 @@ type SandboxPolicy struct {
 // mutation_policy.forbidden) are intentionally absent — see spec §5.4.
 // A patch-apply function MUST reject any attempt to modify fields not present here.
 type GenomePatch struct {
-	Capabilities  *Capabilities  `yaml:"capabilities,omitempty"`
-	Tools         *Tools         `yaml:"tools,omitempty"`
-	ModelPolicy *ModelPolicy `yaml:"model_policy,omitempty"`
+	Capabilities *Capabilities `yaml:"capabilities,omitempty"`
+	Tools        *Tools        `yaml:"tools,omitempty"`
+	ModelPolicy  *ModelPolicy  `yaml:"model_policy,omitempty"`
 	// SECURITY: PromptPolicy.Style is attacker-controlled — see PromptPolicy.Style annotation (issue #35).
 	PromptPolicy  *PromptPolicy  `yaml:"prompt_policy,omitempty"`
 	RoutingPolicy *RoutingPolicy `yaml:"routing_policy,omitempty"`

--- a/pkg/document/types_genome_test.go
+++ b/pkg/document/types_genome_test.go
@@ -50,10 +50,10 @@ func TestPromptPolicy_StyleAttackerControlled(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		yaml      string
-		wantNil   bool
-		checkFn   func(t *testing.T, style map[string]any)
+		name    string
+		yaml    string
+		wantNil bool
+		checkFn func(t *testing.T, style map[string]any)
 	}{
 		{
 			name:    "absent style field yields nil map",

--- a/pkg/document/types_spawn.go
+++ b/pkg/document/types_spawn.go
@@ -3,15 +3,15 @@ package document
 // SpawnProposal is a request to spawn a new agent from one or more parents.
 // Wire type: agent.spawn.proposal.
 type SpawnProposal struct {
-	CandidateID    string         `yaml:"candidate_id"`
-	ParentIDs      []string       `yaml:"parent_ids"`
-	Generation     int            `yaml:"generation,omitempty"`
-	SpawnReason    string         `yaml:"spawn_reason"`
-	RiskLevel      string         `yaml:"risk_level,omitempty"`
-	EvaluationPlan string         `yaml:"evaluation_plan,omitempty"`
+	CandidateID    string   `yaml:"candidate_id"`
+	ParentIDs      []string `yaml:"parent_ids"`
+	Generation     int      `yaml:"generation,omitempty"`
+	SpawnReason    string   `yaml:"spawn_reason"`
+	RiskLevel      string   `yaml:"risk_level,omitempty"`
+	EvaluationPlan string   `yaml:"evaluation_plan,omitempty"`
 	// GenomePatch describes the mutable subset of AgentGenome a proposer may change.
 	// DO_NOT_TOUCH fields are structurally absent. See GenomePatch in types_genome.go.
-	GenomePatch    *GenomePatch   `yaml:"genome_patch,omitempty"`
+	GenomePatch *GenomePatch `yaml:"genome_patch,omitempty"`
 }
 
 // SpawnApproval grants permission to move a candidate agent to sandbox.


### PR DESCRIPTION
## Summary

- Pure whitespace-only struct field alignment fixes in `pkg/document/` applied by gofmt
- No semantic changes — 4 files, 16 insertions/deletions of spaces only

## Test plan

- [ ] `go test ./...` passes
- [ ] `go vet ./...` clean