### PR TITLE
docs: update CLAUDE.md — DefaultValidator singleton and concurrent safety

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,7 @@ internal/gateway/ MCP Gateway implementation
 - Validator: `ValidateStructural` / `ValidateSchema` / `ValidateSemantic` / `Validate` (3-layer composite); `DefaultValidator()`
   - Semantic layer enforces `ValidTransition` for promotion, rollback, quarantine, and retirement
   - `--strict` mode: semantic errors are warnings by default, fatal with `--strict`
+  - `DefaultValidator()` is a `sync.Once` singleton; all per-type `$def` schemas are pre-compiled eagerly in `NewValidator` — safe for concurrent use (no data race)
 - Builder: `NewBuilder` + fluent setters (`ID`, `From`, `To`, `ExecID`, `Status`, `InReplyTo`, `ThreadID`, `Body`, `Field`); `Build()` runs full validation; sticky-error guard rejects reserved envelope keys in `Field()`
   - Convenience: `NewGenomeBuilder`, `NewSpawnProposalBuilder`, `NewTaskRequestBuilder`
 


### PR DESCRIPTION
## Summary

- Document that `DefaultValidator()` is a `sync.Once` singleton with eager per-type schema pre-compilation — safe for concurrent use after package init

## Test plan

- [ ] Documentation-only change — no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)