### PR TITLE
fix(ci): resolve golangci-lint v2 errcheck and staticcheck failures

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -47,3 +47,12 @@ linters:
       # wrapcheck: pkg/document wraps errors from yaml.v3 with fmt.Errorf+%w, which is correct.
       - path: "pkg/document"
         linters: [wrapcheck]
+      # errcheck: defer f.Close() on read-only CLI file opens — close errors are harmless here.
+      - path: "cmd/aga"
+        linters: [errcheck]
+        text: "f\\.Close"
+      # errcheck: fmt.Fprint*/fmt.Fprintln to stdout/stderr in CLI commands — checking print
+      # errors in a terminal CLI adds noise without value (pipe failures surface elsewhere).
+      - path: "cmd/aga"
+        linters: [errcheck]
+        text: "fmt\\.Fprint"

--- a/cmd/aga/inspect.go
+++ b/cmd/aga/inspect.go
@@ -100,32 +100,32 @@ func printInspectJSON(cmd *cobra.Command, doc *document.Document) error {
 	// see types.go security note) is nested under "extra" to match the text
 	// format's separation and prevent key shadowing.
 	out := map[string]any{
-		"type":    string(doc.Envelope.Type),
-		"version": doc.Envelope.Version,
+		"type":    string(doc.Type),
+		"version": doc.Version,
 	}
-	if doc.Envelope.ID != "" {
-		out["id"] = doc.Envelope.ID
+	if doc.ID != "" {
+		out["id"] = doc.ID
 	}
-	if doc.Envelope.From != "" {
-		out["from"] = doc.Envelope.From
+	if doc.From != "" {
+		out["from"] = doc.From
 	}
-	if len(doc.Envelope.To) > 0 {
-		out["to"] = []string(doc.Envelope.To)
+	if len(doc.To) > 0 {
+		out["to"] = []string(doc.To)
 	}
-	if doc.Envelope.ExecID != "" {
-		out["exec_id"] = doc.Envelope.ExecID
+	if doc.ExecID != "" {
+		out["exec_id"] = doc.ExecID
 	}
-	if doc.Envelope.Status != "" {
-		out["status"] = doc.Envelope.Status
+	if doc.Status != "" {
+		out["status"] = doc.Status
 	}
-	if doc.Envelope.InReplyTo != "" {
-		out["in_reply_to"] = doc.Envelope.InReplyTo
+	if doc.InReplyTo != "" {
+		out["in_reply_to"] = doc.InReplyTo
 	}
-	if doc.Envelope.ThreadID != "" {
-		out["thread_id"] = doc.Envelope.ThreadID
+	if doc.ThreadID != "" {
+		out["thread_id"] = doc.ThreadID
 	}
-	if doc.Envelope.CreatedAt != "" {
-		out["created_at"] = doc.Envelope.CreatedAt
+	if doc.CreatedAt != "" {
+		out["created_at"] = doc.CreatedAt
 	}
 	if len(doc.Extra) > 0 {
 		out["extra"] = doc.Extra


### PR DESCRIPTION
## Summary

PRs #47 #48 #49 #57 #58 all merged with failing CI. golangci-lint v2 in CI flagged violations that local v1 doesn't catch.

- `cmd/aga/inspect.go`: remove redundant `Envelope.` selector in `printInspectJSON` (staticcheck QF1008 — `Document` embeds `Envelope`, so `doc.X` is equivalent to `doc.Envelope.X`)
- `.golangci.yaml`: add `errcheck` exclusions for:
  - `defer f.Close()` in `cmd/aga/` — read-only file opens; close errors are harmless
  - `fmt.Fprint*` in `cmd/aga/` — terminal print calls; checking every write adds noise without value

## Test plan

- [ ] `go test ./...` passes
- [ ] `go vet ./...` clean
- [ ] CI (golangci-lint v2) passes — this is the primary goal