### PR TITLE
chore(workflow): add CI gate before merge in fix-review and ship

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -117,5 +117,6 @@ If fix-review timed out waiting for merge, check `gh pr view {pr-number} --json 
 - Never skip the TDD cycle — tests MUST fail before implementation
 - Never skip parallel review — all three agents must run
 - Never merge without fix-review — even if parallel review finds nothing
+- **Never merge without green CI** — `gh pr checks {number}` must show all checks passing before merge; the repo ruleset does NOT require passing checks so auto-merge will complete even with failures
 - Branch must have a corresponding open issue — no orphan branches
 - `go test ./... && go vet ./...` must be green before creating the PR

--- a/.claude/skills/fix-review/SKILL.md
+++ b/.claude/skills/fix-review/SKILL.md
@@ -234,6 +234,39 @@ Post collapsible PR comment if enabled.
 
 ---
 
+## STEP 8.5: Wait for CI
+
+After the Arbiter push, verify CI passes before attempting merge. The repo ruleset requires PRs but **not** passing status checks — `--auto` will complete immediately even with CI failures.
+
+```bash
+SHA=$(gh pr view {number} --repo valpere/aga2aga --json headRefOid --jq '.headRefOid')
+
+for i in $(seq 1 60); do
+  STATUS=$(gh api repos/valpere/aga2aga/commits/$SHA/check-runs --jq '
+    if .check_runs | length == 0 then "pending"
+    elif ([.check_runs[] | select(.conclusion == "failure" or .conclusion == "cancelled")] | length) > 0 then "failure"
+    elif ([.check_runs[] | select(.status != "completed")] | length) > 0 then "pending"
+    else "success"
+    end')
+  case "$STATUS" in
+    success) echo "CI passed"; break ;;
+    failure) echo "CI FAILED — do NOT merge. Fix lint/test errors first."; exit 1 ;;
+    pending) echo "CI pending... ($((i * 5))s)"; sleep 5 ;;
+  esac
+done
+
+if [ "$STATUS" != "success" ]; then
+  echo "WARNING: CI still pending after 5 minutes"
+  gh pr checks {number} --repo valpere/aga2aga
+  echo "Do NOT merge until CI is green."
+  exit 1
+fi
+```
+
+If CI fails: **stop**. Do NOT proceed to auto-merge. Report the failure to the user. Fix the lint/test errors in a new commit on the same branch, push, and re-run from STEP 8.5.
+
+---
+
 ## STEP 9: Auto-merge
 
 The `main` branch requires a PR (ruleset "prs"). Auto-merge is enabled on the repo, so `--auto` queues the merge and GitHub completes it once all required checks pass.


### PR DESCRIPTION
## Summary

- **fix-review SKILL.md**: Added STEP 8.5 between Arbiter push and auto-merge — polls \`gh api repos/valpere/aga2aga/commits/$SHA/check-runs\` until all checks complete; exits non-zero if any check fails, blocking the merge
- **ship SKILL.md**: Added explicit rule "Never merge without green CI" with a note explaining that the repo ruleset requires PRs but NOT passing checks — so \`gh pr merge --auto\` completes immediately regardless of CI state

## Root cause

PRs #47–#58 all merged with failing golangci-lint v2 runs.  
The repo's "prs" ruleset requires a PR but has no required status checks.  
`gh pr merge --auto` only blocks on *required* checks — so it completed immediately despite failing CI.

## Test plan

- [ ] fix-review SKILL.md contains "STEP 8.5: Wait for CI"
- [ ] ship SKILL.md rules section contains "Never merge without green CI"
- [ ] go test ./... passes