### PR TITLE
feat: annotate lifecycle wire fields as attacker-controlled (#39)

### DIFF
--- a/pkg/document/types_lifecycle.go
+++ b/pkg/document/types_lifecycle.go
@@ -5,12 +5,13 @@ package document
 //
 // SECURITY: FromStatus and ToStatus are self-reported wire strings supplied by the sender.
 // Executors MUST derive the current status from an authoritative state-store and call
-// lifecycle.ValidTransition() — never trust the wire values for transition decisions (CWE-20).
+// document.ValidTransition() — never trust the wire values for transition decisions (CWE-20).
+// FromStatus is required on the wire; the semantic validator returns an error when absent.
 // Reason is an opaque logging label; MUST NOT influence transition logic.
 type Promotion struct {
 	TargetAgent string         `yaml:"target_agent"`
-	FromStatus  LifecycleState `yaml:"from_status"` // self-reported; use only for logging — validate via lifecycle.ValidTransition()
-	ToStatus    LifecycleState `yaml:"to_status"`   // self-reported; use only for logging — validate via lifecycle.ValidTransition()
+	FromStatus  LifecycleState `yaml:"from_status"` // self-reported; use only for logging — validate via document.ValidTransition()
+	ToStatus    LifecycleState `yaml:"to_status"`   // self-reported; use only for logging — validate via document.ValidTransition()
 	Reason      string         `yaml:"reason,omitempty"` // opaque logging label — MUST NOT influence transition logic
 }
 
@@ -19,12 +20,13 @@ type Promotion struct {
 //
 // SECURITY: FromStatus and ToStatus are self-reported wire strings supplied by the sender.
 // Executors MUST derive the current status from an authoritative state-store and call
-// lifecycle.ValidTransition() — never trust the wire values for transition decisions (CWE-20).
+// document.ValidTransition() — never trust the wire values for transition decisions (CWE-20).
+// FromStatus is required on the wire; the semantic validator returns an error when absent.
 // Reason is an opaque logging label; MUST NOT influence transition logic.
 type Rollback struct {
 	TargetAgent string         `yaml:"target_agent"`
-	FromStatus  LifecycleState `yaml:"from_status"` // self-reported; use only for logging — validate via lifecycle.ValidTransition()
-	ToStatus    LifecycleState `yaml:"to_status"`   // self-reported; use only for logging — validate via lifecycle.ValidTransition()
+	FromStatus  LifecycleState `yaml:"from_status"` // self-reported; use only for logging — validate via document.ValidTransition()
+	ToStatus    LifecycleState `yaml:"to_status"`   // self-reported; use only for logging — validate via document.ValidTransition()
 	Reason      string         `yaml:"reason,omitempty"` // opaque logging label — MUST NOT influence transition logic
 }
 
@@ -32,16 +34,16 @@ type Rollback struct {
 // Wire type: agent.quarantine.
 //
 // FromStatus is optional on the wire. When absent, the orchestrator MUST
-// perform a state-store lookup before calling ValidTransition.
+// perform a state-store lookup before calling document.ValidTransition().
 //
 // SECURITY: FromStatus is a self-reported wire string. Executors MUST derive the
-// current status from an authoritative state-store and call lifecycle.ValidTransition()
+// current status from an authoritative state-store and call document.ValidTransition()
 // — never trust the wire value for transition decisions (CWE-20).
 // Reason is an opaque logging label; MUST NOT influence transition logic.
 type Quarantine struct {
 	TargetAgent           string         `yaml:"target_agent"`
 	Reason                string         `yaml:"reason"`                          // opaque logging label — MUST NOT influence transition logic
-	FromStatus            LifecycleState `yaml:"from_status,omitempty"`           // self-reported; use only for logging — validate via lifecycle.ValidTransition()
+	FromStatus            LifecycleState `yaml:"from_status,omitempty"`           // self-reported; use only for logging — validate via document.ValidTransition()
 	InvestigationRequired bool           `yaml:"investigation_required,omitempty"`
 }
 
@@ -49,24 +51,34 @@ type Quarantine struct {
 // Wire type: agent.retirement.
 //
 // FromStatus is optional on the wire. When absent, the orchestrator MUST
-// perform a state-store lookup before calling ValidTransition.
+// perform a state-store lookup before calling document.ValidTransition().
 //
 // SECURITY: FromStatus is a self-reported wire string. Executors MUST derive the
-// current status from an authoritative state-store and call lifecycle.ValidTransition()
+// current status from an authoritative state-store and call document.ValidTransition()
 // — never trust the wire value for transition decisions (CWE-20).
 // Reason is an opaque logging label; MUST NOT influence transition logic.
+// RetirementMode is a self-reported hint; MUST NOT gate control flow without
+// validation against an allowed-modes list. ReplaceWith is a self-reported list
+// of successor agent IDs; executors MUST verify each ID in the state-store before
+// any auto-promotion or auto-spawn decision.
 type Retirement struct {
 	TargetAgent    string         `yaml:"target_agent"`
-	Reason         string         `yaml:"reason"`                    // opaque logging label — MUST NOT influence transition logic
-	FromStatus     LifecycleState `yaml:"from_status,omitempty"`     // self-reported; use only for logging — validate via lifecycle.ValidTransition()
-	RetirementMode string         `yaml:"retirement_mode,omitempty"`
-	ReplaceWith    []string       `yaml:"replace_with,omitempty"`
+	Reason         string         `yaml:"reason"`                          // opaque logging label — MUST NOT influence transition logic
+	FromStatus     LifecycleState `yaml:"from_status,omitempty"`           // self-reported; use only for logging — validate via document.ValidTransition()
+	RetirementMode string         `yaml:"retirement_mode,omitempty"`       // self-reported hint — MUST NOT gate control flow without validation
+	ReplaceWith    []string       `yaml:"replace_with,omitempty"`          // self-reported IDs — MUST verify each in state-store before auto-promotion
 }
 
 // RecombineProposal requests creation of a new agent from two or more parents.
 // Wire type: agent.recombine.proposal.
+//
+// SECURITY: CandidateID and ParentIDs are self-reported wire strings supplied by the
+// sender. Executors MUST verify that CandidateID does not collide with an existing
+// agent_id in the authoritative state-store before creating the genome. ParentIDs MUST
+// be validated against the state-store — never trust the wire values for lineage
+// attribution (CWE-20). Goal is an opaque label; MUST NOT influence spawn authorization.
 type RecombineProposal struct {
-	CandidateID string   `yaml:"candidate_id"`
-	ParentIDs   []string `yaml:"parent_ids"`
-	Goal        string   `yaml:"goal"`
+	CandidateID string   `yaml:"candidate_id"` // self-reported; MUST verify no collision in state-store
+	ParentIDs   []string `yaml:"parent_ids"`   // self-reported; MUST validate each ID in state-store
+	Goal        string   `yaml:"goal"`         // opaque label — MUST NOT influence spawn authorization
 }

--- a/pkg/document/types_lifecycle_test.go
+++ b/pkg/document/types_lifecycle_test.go
@@ -10,9 +10,9 @@ import (
 // TestLifecycle_WireFieldsAreAttackerControlled is a security surface documentation test.
 // FromStatus and ToStatus on lifecycle types are self-reported wire strings — the parse
 // layer accepts any string value verbatim. Executors MUST derive authoritative state from
-// a trusted state-store and call lifecycle.ValidTransition(), never trusting wire values.
+// a trusted state-store and call document.ValidTransition(), never trusting wire values.
 // Reason is an opaque logging label — MUST NOT influence transition logic.
-// This test locks the open-wire-string contract.
+// This test locks the open-wire-string contract using the production document.Parse() path.
 // DO NOT DELETE — documents CWE-20 surface from issue #39.
 func TestLifecycle_WireFieldsAreAttackerControlled(t *testing.T) {
 	t.Parallel()
@@ -69,8 +69,8 @@ reason: "DROP TABLE agents"
 				if r.ToStatus != "injected-to" {
 					t.Errorf("ToStatus = %q, want injected-to — open-wire contract broken", r.ToStatus)
 				}
-				if r.Reason == "" {
-					t.Error("Reason is empty — open-wire contract: arbitrary reason strings must be preserved")
+				if r.Reason != "DROP TABLE agents" {
+					t.Errorf("Reason = %q, want DROP TABLE agents — open-wire contract: arbitrary reason strings must be preserved verbatim", r.Reason)
 				}
 			},
 		},
@@ -93,8 +93,8 @@ from_status: injected-state
 				if q.FromStatus != "injected-state" {
 					t.Errorf("FromStatus = %q, want injected-state — open-wire contract broken", q.FromStatus)
 				}
-				if q.Reason == "" {
-					t.Error("Reason is empty — open-wire contract: arbitrary reason strings must be preserved")
+				if q.Reason != "<script>alert(1)</script>" {
+					t.Errorf("Reason = %q, want <script>alert(1)</script> — open-wire contract: arbitrary reason strings must be preserved verbatim", q.Reason)
 				}
 			},
 		},
@@ -117,8 +117,8 @@ from_status: injected-state
 				if r.FromStatus != "injected-state" {
 					t.Errorf("FromStatus = %q, want injected-state — open-wire contract broken", r.FromStatus)
 				}
-				if r.Reason == "" {
-					t.Error("Reason is empty — open-wire contract: arbitrary reason strings must be preserved")
+				if r.Reason != "$(rm -rf /)" {
+					t.Errorf("Reason = %q, want $(rm -rf /) — open-wire contract: arbitrary reason strings must be preserved verbatim", r.Reason)
 				}
 			},
 		},
@@ -128,12 +128,15 @@ from_status: injected-state
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			var doc document.Document
-			if err := yaml.Unmarshal([]byte(tc.raw), &doc); err != nil {
-				t.Fatalf("yaml.Unmarshal error = %v", err)
+			// Use document.Parse() — the production wire-parse path — so the test
+			// exercises the same code path as real incoming documents and includes
+			// the MaxDocumentBytes guard.
+			doc, err := document.Parse([]byte("---\n" + tc.raw + "---\n"))
+			if err != nil {
+				t.Fatalf("Parse() error = %v", err)
 			}
 
-			tc.checkFn(t, &doc)
+			tc.checkFn(t, doc)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Add struct-level `// SECURITY:` comments to `Promotion`, `Rollback`, `Quarantine`, `Retirement`, and `RecombineProposal` in `pkg/document/types_lifecycle.go`
- `FromStatus`/`ToStatus` annotated as self-reported wire strings; executors MUST call `document.ValidTransition()` with authoritative state-store data — never trust wire values (CWE-20)
- `Reason` fields annotated as opaque logging labels that MUST NOT influence transition logic
- `Retirement.RetirementMode` and `ReplaceWith` annotated as self-reported wire fields
- `RecombineProposal.CandidateID`/`ParentIDs` annotated: MUST verify against state-store before genome creation
- Document `from_status` required-vs-optional asymmetry between Promotion/Rollback and Quarantine/Retirement
- Add `TestLifecycle_WireFieldsAreAttackerControlled` (table-driven, 4 cases) to lock the open-wire-string contract; uses `document.Parse()` — the production wire-parse path

## Test plan

- [ ] `go test ./...` passes
- [ ] `go vet ./...` clean
- [ ] `TestLifecycle_WireFieldsAreAttackerControlled` covers Promotion, Rollback, Quarantine, Retirement

Closes #39