### PR TITLE
chore: update CLAUDE.md after #53 merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,7 @@ internal/gateway/ MCP Gateway implementation
 - `aga validate <file>` — 3-layer validation; `--strict` flag
 - `aga create <type>` — build any registered message type via `--id/--from/--to/--exec-id/--field/--out`
 - `aga inspect <file>` — print envelope fields; `--format text|json`; JSON output nests `Extra` under `"extra"` key
+- `readAndParseFile` helper (`helpers.go`) — shared open/size-check/parse; `ErrDocumentTooLarge` sentinel for `errors.Is` testing
 
 #### Security invariants (pkg/document)
 


### PR DESCRIPTION
## Summary

- Document `readAndParseFile` helper and `ErrDocumentTooLarge` sentinel in the cmd/aga section

Post-merge housekeeping for #53 / PR #71.