### PR TITLE
fix(cli): harden readAndParseFile — path traversal + path leak

### DIFF
--- a/cmd/aga/helpers.go
+++ b/cmd/aga/helpers.go
@@ -16,13 +16,28 @@ var ErrDocumentTooLarge = errors.New("document exceeds maximum size")
 // readAndParseFile opens path, enforces the MaxDocumentBytes limit, and
 // returns the parsed Document. Returns a descriptive error on open, read,
 // size, or parse failure.
+//
+// SECURITY: path MUST be a value supplied directly by the local operator
+// (e.g., a CLI argument). It MUST NOT be derived from document content,
+// agent-controlled wire data, or any remote input. Callers in daemon or
+// MCP-handler contexts must perform filepath.EvalSymlinks and root-confinement
+// checks before calling this function. (CWE-22, CWE-61)
 func readAndParseFile(path string) (*document.Document, error) {
-	f, err := os.Open(path)
+	resolved, err := filepath.EvalSymlinks(filepath.Clean(path))
+	if err != nil {
+		return nil, fmt.Errorf("open %q: %w", filepath.Base(path), err)
+	}
+
+	f, err := os.Open(resolved)
 	if err != nil {
 		return nil, fmt.Errorf("open %q: %w", filepath.Base(path), err)
 	}
 	defer f.Close()
 
+	// LimitReader cap is MaxDocumentBytes+1 so that a file of exactly
+	// MaxDocumentBytes passes (len(raw) == MaxDocumentBytes, not >),
+	// while any larger file produces len(raw) == MaxDocumentBytes+1 and
+	// is caught by the check below. DO NOT reduce the cap to MaxDocumentBytes.
 	raw, err := io.ReadAll(io.LimitReader(f, document.MaxDocumentBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("read %q: %w", filepath.Base(path), err)

--- a/cmd/aga/validate.go
+++ b/cmd/aga/validate.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/valpere/aga2aga/pkg/document"
@@ -35,7 +36,7 @@ func newValidateCmd() *cobra.Command {
 			if len(fatal) > 0 {
 				return fmt.Errorf("validation failed: %d error(s)", len(fatal))
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "OK: %s\n", path)
+			fmt.Fprintf(cmd.OutOrStdout(), "OK: %s\n", filepath.Base(path))
 			return nil
 		},
 	}


### PR DESCRIPTION
## Summary

Security findings from the post-#71 review (issue #73):

- **MEDIUM (CWE-22/61):** Add `filepath.EvalSymlinks(filepath.Clean(path))` before `os.Open` — prevents symlink traversal if this function is ever reused in a daemon/MCP path
- **MEDIUM (CWE-209):** Use `filepath.Base(path)` in `validate` success output — matches error path behavior, no full-path leak in CI/log contexts
- **LOW:** Add `DO NOT reduce the cap` comment on the sentinel-read pattern in helpers.go
- **LOW:** Extend godoc with explicit trust-boundary statement (path MUST be operator-supplied)

## Test plan

- [ ] `go test ./...` passes (all 3 subtests including nonexistent path via EvalSymlinks error)
- [ ] `go vet ./...` clean

Closes #73