### PR TITLE
feat: stub interfaces — transport, identity, negotiation

### DIFF
--- a/pkg/identity/types.go
+++ b/pkg/identity/types.go
@@ -1,11 +1,15 @@
 package identity
 
+import "crypto/ed25519"
+
 // Identity represents a cryptographic agent identity.
-// The PublicKey field holds an Ed25519 public key; key generation
-// and signing logic are implemented in Phase 3.
+// PublicKey uses the stdlib ed25519.PublicKey type, which is always 32 bytes.
+// Key generation and signing logic are implemented in Phase 3.
+//
+// Zero value is not usable; construct via the Phase 3 identity package.
 type Identity struct {
 	Pseudonym string
-	PublicKey []byte // Ed25519 public key — Phase 3 fills this in
+	PublicKey ed25519.PublicKey // Ed25519 public key (32 bytes) — Phase 3 fills this in
 }
 
 // Signer is the signing interface for agent identities.
@@ -15,5 +19,9 @@ type Signer interface {
 	Sign(data []byte) ([]byte, error)
 
 	// Verify checks that sig is a valid signature over data.
-	Verify(data, sig []byte) bool
+	// Returns (false, nil) for a cryptographically invalid signature,
+	// and (false, error) for a configuration or implementation fault
+	// (e.g., nil or zero-length key). Callers MUST treat a non-nil error
+	// as an indeterminate result — not as a simple auth rejection. (CWE-252)
+	Verify(data, sig []byte) (bool, error)
 }

--- a/pkg/negotiation/types.go
+++ b/pkg/negotiation/types.go
@@ -1,23 +1,29 @@
 package negotiation
 
+import "github.com/valpere/aga2aga/pkg/protocol"
+
 // NegotiationState is the current phase of a negotiation session.
-// Values correspond to the negotiation.* message types in pkg/protocol.
+// Values are derived from pkg/protocol MessageType constants to prevent
+// silent divergence if the protocol registry is ever updated.
 type NegotiationState string
 
 const (
-	StatePropose  NegotiationState = "negotiation.propose"
-	StateAccept   NegotiationState = "negotiation.accept"
-	StateReject   NegotiationState = "negotiation.reject"
-	StateCounter  NegotiationState = "negotiation.counter"
-	StateClarify  NegotiationState = "negotiation.clarify"
-	StateDelegate NegotiationState = "negotiation.delegate"
-	StateCommit   NegotiationState = "negotiation.commit"
-	StateAbort    NegotiationState = "negotiation.abort"
+	StatePropose  NegotiationState = NegotiationState(protocol.NegotiationPropose)
+	StateAccept   NegotiationState = NegotiationState(protocol.NegotiationAccept)
+	StateReject   NegotiationState = NegotiationState(protocol.NegotiationReject)
+	StateCounter  NegotiationState = NegotiationState(protocol.NegotiationCounter)
+	StateClarify  NegotiationState = NegotiationState(protocol.NegotiationClarify)
+	StateDelegate NegotiationState = NegotiationState(protocol.NegotiationDelegate)
+	StateCommit   NegotiationState = NegotiationState(protocol.NegotiationCommit)
+	StateAbort    NegotiationState = NegotiationState(protocol.NegotiationAbort)
 )
 
 // NegotiationTransition reports whether transitioning from → to is valid.
-// Full state-machine logic is implemented in Phase 4; this stub always
-// returns false to satisfy interface consumers during Phase 1.
+// Full state-machine logic is implemented in Phase 4.
+//
+// STUB: always returns false for every input, including identity transitions
+// (from == to). Do NOT use this function as a gate or guard decision before
+// Phase 4 is implemented — every call will silently reject valid transitions.
 func NegotiationTransition(from, to NegotiationState) bool {
 	return false
 }

--- a/pkg/transport/types.go
+++ b/pkg/transport/types.go
@@ -17,6 +17,10 @@ type Transport interface {
 	Subscribe(ctx context.Context, topic string) (<-chan *document.Document, error)
 
 	// Ack acknowledges a message by its transport-layer message ID.
+	// msgID is the opaque delivery token assigned by the concrete transport
+	// on receive (e.g., a Redis Streams entry ID). Callers MUST obtain msgID
+	// from the transport's internal pending map keyed on document ID — never
+	// from document content or Document.Extra, which is attacker-controlled.
 	Ack(ctx context.Context, msgID string) error
 
 	// Close shuts down the transport and releases resources.


### PR DESCRIPTION
## Summary

- `pkg/transport/types.go` — `Transport` interface: `Publish`, `Subscribe`, `Ack`, `Close`; context on all I/O methods; `Ack` doc specifies msgID MUST come from pending map, not `Document.Extra`
- `pkg/identity/types.go` — `Identity` struct (`Pseudonym`, `PublicKey ed25519.PublicKey`); `Signer` interface with `Sign` + `Verify(data, sig []byte) (bool, error)` (error-aware for config faults)
- `pkg/negotiation/types.go` — `NegotiationState` named string type; 8 constants derived from `pkg/protocol` (no drift); `NegotiationTransition` stub (always false, explicitly NOT for gate use before Phase 4)

## Test plan

- [ ] `go build ./...` passes (all 3 packages compile)
- [ ] `go test ./...` passes (existing suite unaffected)
- [ ] `go vet ./...` clean
- [ ] No Redis/external imports in `pkg/transport`
- [ ] `NegotiationState` constants byte-equal to `pkg/protocol` constants

Closes #22