### PR TITLE
feat(gateway): policy enforcement — embedded and remote modes (#90)

### DIFF
--- a/internal/gateway/policy.go
+++ b/internal/gateway/policy.go
@@ -90,7 +90,7 @@ func (e *HTTPEnforcer) Allowed(ctx context.Context, source, target string) (bool
 	if err != nil {
 		return false, fmt.Errorf("gateway/policy: http evaluate: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return false, fmt.Errorf("gateway/policy: evaluate returned status %d", resp.StatusCode)

--- a/internal/gateway/policy_test.go
+++ b/internal/gateway/policy_test.go
@@ -115,7 +115,7 @@ func TestHTTPEnforcer_Allowed(t *testing.T) {
 					return
 				}
 				w.Header().Set("Content-Type", "application/json")
-				fmt.Fprint(w, `{"action":"allow"}`)
+				_, _ = fmt.Fprint(w, `{"action":"allow"}`)
 			},
 			wantAllow: true,
 		},
@@ -123,7 +123,7 @@ func TestHTTPEnforcer_Allowed(t *testing.T) {
 			name: "deny response",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				fmt.Fprint(w, `{"action":"deny"}`)
+				_, _ = fmt.Fprint(w, `{"action":"deny"}`)
 			},
 			wantAllow: false,
 		},


### PR DESCRIPTION
## Summary

- Adds `PolicyEnforcer` interface (`Allowed(ctx, source, target string) (bool, error)`) to `internal/gateway/policy.go`
- `EmbeddedEnforcer`: in-process evaluation via `admin.PolicyStore` + `admin.Evaluate` — for single-node deployments
- `HTTPEnforcer`: remote evaluation via `GET /api/v1/evaluate?source=X&target=Y` with Bearer token — for decoupled deployments
- URL validation in `NewHTTPEnforcer` (rejects non-http/https and empty hosts — CWE-918)
- `io.LimitReader(4KiB)` on HTTP response body (CWE-400)
- Bearer token never in error messages (CWE-532)

## Test plan

- [x] `go test ./...` passes (11 tests: 3 EmbeddedEnforcer, 4 HTTPEnforcer, 4 invalid-URL)
- [x] `go vet ./...` clean
- [x] Race detector: `go test -race ./internal/gateway/...`

Closes #90