### PR TITLE
fix(makefile): produce named binaries in bin/ on make build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ go.work.sum
 .vscode/
 
 aga
+bin/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help build test test-integration lint validate docker docker-admin docker-images up down ps logs tidy
+.PHONY: help build clean test test-integration lint validate docker docker-admin docker-images up down ps logs tidy
 
 ## help: print this help message
 help:
@@ -8,9 +8,16 @@ help:
 	@echo ""
 	@sed -n 's/^## //p' $(MAKEFILE_LIST) | column -t -s ':' | sed -e 's/^/  /'
 
-## build: compile all packages
+## build: compile all packages and produce binaries in bin/
 build:
-	go build ./...
+	@mkdir -p bin
+	go build -o bin/aga2aga         ./cmd/aga2aga/
+	go build -o bin/aga2aga-admin   ./cmd/admin/
+	go build -o bin/aga2aga-gateway ./cmd/gateway/
+
+## clean: remove compiled binaries
+clean:
+	rm -rf bin/
 
 ## test: run all tests
 test:


### PR DESCRIPTION
## Summary

- `make build` now produces three named binaries under `bin/`:
  - `bin/aga2aga` (CLI tool)
  - `bin/aga2aga-admin` (admin server)
  - `bin/aga2aga-gateway` (MCP gateway)
- Add `make clean` to remove `bin/`
- Add `bin/` to `.gitignore`

## Test plan

- [ ] `make build` → `ls bin/` shows all three binaries
- [ ] `make clean` → `bin/` removed
- [ ] `bin/aga2aga-gateway --help` responds without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)