### PR TITLE
fix(gitignore): ignore root-level binaries from accidental go build ./...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,13 @@ go.work.sum
 .idea/
 .vscode/
 
+# Root-level binaries produced by accidental `go build ./...` in repo root
 aga
+aga2aga
+aga2aga-admin
+aga2aga-gateway
+gateway
+admin
+
+# Compiled binaries directory (produced by `make build`)
 bin/


### PR DESCRIPTION
## Summary

- `go build ./...` in the repo root produces binaries named after their `cmd/` subdirectory (`gateway`, `admin`, `aga`) in the working directory — these were showing up as untracked files
- Adds all known root-level binary names to `.gitignore` so they can never appear in `git status` again
- Deletes the stale `gateway` binary that was sitting in the repo root since March 26

🤖 Generated with [Claude Code](https://claude.com/claude-code)