### PR TITLE
fix(gateway): handle OAuth discovery with sub-path resource URLs

### DIFF
--- a/internal/gateway/http_handler.go
+++ b/internal/gateway/http_handler.go
@@ -9,27 +9,31 @@ import (
 // NewMCPHTTPHandler returns an http.Handler that serves the given MCP server
 // over the streamable HTTP transport.
 //
-// OAuth discovery paths (/.well-known/oauth-protected-resource and
-// /.well-known/oauth-authorization-server) return 404 Not Found, signalling
-// to MCP clients that no OAuth is configured. Without this, the MCP SDK's
-// catch-all handler returns 405 for these paths, which some clients (Claude
-// Code) interpret as an authentication challenge and start an unwanted OAuth
-// flow, causing connection failures even when the server requires no auth.
+// OAuth discovery paths return 404 Not Found, signalling to MCP clients that
+// no OAuth is configured. Without this, the MCP SDK's catch-all handler returns
+// 405 for these paths, which some clients (Claude Code) interpret as an auth
+// challenge and start an unwanted OAuth flow.
+//
+// Both exact paths and sub-path variants are handled. RFC 9728 appends the
+// resource path to the well-known URL, so a client configured with
+// http://host/mcp fetches /.well-known/oauth-protected-resource/mcp, not
+// /.well-known/oauth-protected-resource. The {path...} wildcard routes cover
+// these sub-path variants; Go 1.22 wildcards require separate exact routes
+// since {path...} does not match an empty segment.
 func NewMCPHTTPHandler(srv *mcpsdk.Server) http.Handler {
 	mcpHandler := mcpsdk.NewStreamableHTTPHandler(
 		func(_ *http.Request) *mcpsdk.Server { return srv },
 		nil,
 	)
+	notFound := func(w http.ResponseWriter, r *http.Request) { http.NotFound(w, r) }
 	mux := http.NewServeMux()
-	// Intercept OAuth discovery before the MCP catch-all. Returning 404 tells
-	// clients that this server has no OAuth authorization server — they should
-	// connect without OAuth.
-	mux.HandleFunc("GET /.well-known/oauth-protected-resource", func(w http.ResponseWriter, r *http.Request) {
-		http.NotFound(w, r)
-	})
-	mux.HandleFunc("GET /.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
-		http.NotFound(w, r)
-	})
+	// Return 404 for all OAuth/OIDC discovery paths (exact + sub-path variants).
+	mux.HandleFunc("GET /.well-known/oauth-protected-resource", notFound)
+	mux.HandleFunc("GET /.well-known/oauth-protected-resource/{path...}", notFound)
+	mux.HandleFunc("GET /.well-known/oauth-authorization-server", notFound)
+	mux.HandleFunc("GET /.well-known/oauth-authorization-server/{path...}", notFound)
+	mux.HandleFunc("GET /.well-known/openid-configuration", notFound)
+	mux.HandleFunc("GET /.well-known/openid-configuration/{path...}", notFound)
 	mux.Handle("/", mcpHandler)
 	return mux
 }

--- a/internal/gateway/http_handler_test.go
+++ b/internal/gateway/http_handler_test.go
@@ -19,9 +19,16 @@ func TestNewMCPHTTPHandler_OAuthDiscovery(t *testing.T) {
 	srv := httptest.NewServer(gateway.NewMCPHTTPHandler(g.Server()))
 	defer srv.Close()
 
+	// RFC 9728 appends the resource path to the discovery URL, so a client
+	// configured with http://host:port/mcp fetches /.well-known/…/mcp, not /.well-known/….
+	// All variants must return 404 so that clients skip OAuth entirely.
 	oauthPaths := []string{
 		"/.well-known/oauth-protected-resource",
+		"/.well-known/oauth-protected-resource/mcp",
 		"/.well-known/oauth-authorization-server",
+		"/.well-known/oauth-authorization-server/mcp",
+		"/.well-known/openid-configuration",
+		"/.well-known/openid-configuration/mcp",
 	}
 	for _, path := range oauthPaths {
 		resp, err := http.Get(srv.URL + path)


### PR DESCRIPTION
## Summary

- **Root cause**: PR #142 only handled exact OAuth discovery paths (`/.well-known/oauth-protected-resource`). RFC 9728 appends the resource path, so `http://localhost:3001/mcp` causes discovery at `/.well-known/oauth-protected-resource/mcp` — which missed our route and fell through to the MCP catch-all (405 → Claude Code starts OAuth flow)
- **Fix**: Add `{path...}` wildcard routes alongside exact routes for all three discovery paths (`oauth-protected-resource`, `oauth-authorization-server`, `openid-configuration`). Go 1.22 wildcards require separate exact routes since `{path...}` doesn't match empty segments
- **Also fixed**: `llm-council-backend/.mcp.json` — changed from `type: sse, url: .../mcp` to `type: http, url: http://localhost:3001`

## Test plan

- [ ] `TestNewMCPHTTPHandler_OAuthDiscovery` — all 6 paths (root + `/mcp` sub-path for each) return 404
- [ ] `TestNewMCPHTTPHandler_MCPInitialize` — MCP init still returns 200
- [ ] `go test ./... && go vet ./...` pass
- [ ] Manual: rebuild + restart gateway, backend agent connects without "needs authentication" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)