### PR TITLE
fix(skills): retire devstral-2:123b in fix-review ollama fallback

### DIFF
--- a/.claude/skills/fix-review/SKILL.md
+++ b/.claude/skills/fix-review/SKILL.md
@@ -93,13 +93,13 @@ If CI is pending for >5 minutes: warn and stop. Do NOT start review rounds witho
 
 **Round 1** — full PR diff:
 ```bash
-DIFF=$(gh pr diff "${PR_NUMBER}")
+DIFF=$(gh pr diff --no-color "${PR_NUMBER}")
 ```
 
 **Rounds 2-3** — delta (default) or full per `diff_scope`:
 ```bash
 DIFF=$(git diff HEAD~1)                                           # delta
-DIFF=$(gh pr diff "${PR_NUMBER}")  # full
+DIFF=$(gh pr diff --no-color "${PR_NUMBER}")  # full
 ```
 
 If `DIFF` is empty for a delta round, fall back to the full PR diff.
@@ -232,7 +232,7 @@ Before each new round, compare identifiers against the previous round.
 
 Get full current PR diff:
 ```bash
-DIFF=$(gh pr diff "${PR_NUMBER}")
+DIFF=$(gh pr diff --no-color "${PR_NUMBER}")
 ```
 
 Compile findings log for rounds 1-3: model, every item flagged, status (fixed/skipped/open).

--- a/.claude/skills/fix-review/SKILL.md
+++ b/.claude/skills/fix-review/SKILL.md
@@ -93,13 +93,13 @@ If CI is pending for >5 minutes: warn and stop. Do NOT start review rounds witho
 
 **Round 1** — full PR diff:
 ```bash
-DIFF=$(gh pr diff --no-color "${PR_NUMBER}")
+DIFF=$(gh pr diff --color=never "${PR_NUMBER}")
 ```
 
 **Rounds 2-3** — delta (default) or full per `diff_scope`:
 ```bash
 DIFF=$(git diff HEAD~1)                                           # delta
-DIFF=$(gh pr diff --no-color "${PR_NUMBER}")  # full
+DIFF=$(gh pr diff --color=never "${PR_NUMBER}")  # full
 ```
 
 If `DIFF` is empty for a delta round, fall back to the full PR diff.
@@ -232,7 +232,7 @@ Before each new round, compare identifiers against the previous round.
 
 Get full current PR diff:
 ```bash
-DIFF=$(gh pr diff --no-color "${PR_NUMBER}")
+DIFF=$(gh pr diff --color=never "${PR_NUMBER}")
 ```
 
 Compile findings log for rounds 1-3: model, every item flagged, status (fixed/skipped/open).

--- a/.claude/skills/fix-review/SKILL.md
+++ b/.claude/skills/fix-review/SKILL.md
@@ -93,13 +93,13 @@ If CI is pending for >5 minutes: warn and stop. Do NOT start review rounds witho
 
 **Round 1** — full PR diff:
 ```bash
-DIFF=$(git diff $(git merge-base HEAD origin/${BASE_BRANCH})...HEAD)
+DIFF=$(gh pr diff "${PR_NUMBER}")
 ```
 
 **Rounds 2-3** — delta (default) or full per `diff_scope`:
 ```bash
 DIFF=$(git diff HEAD~1)                                           # delta
-DIFF=$(git diff $(git merge-base HEAD origin/${BASE_BRANCH})...HEAD)  # full
+DIFF=$(gh pr diff "${PR_NUMBER}")  # full
 ```
 
 If `DIFF` is empty for a delta round, fall back to the full PR diff.
@@ -232,7 +232,7 @@ Before each new round, compare identifiers against the previous round.
 
 Get full current PR diff:
 ```bash
-DIFF=$(git diff $(git merge-base HEAD origin/${BASE_BRANCH})...HEAD)
+DIFF=$(gh pr diff "${PR_NUMBER}")
 ```
 
 Compile findings log for rounds 1-3: model, every item flagged, status (fixed/skipped/open).

--- a/.claude/skills/fix-review/config.yaml
+++ b/.claude/skills/fix-review/config.yaml
@@ -7,7 +7,7 @@
 #
 # To switch provider: "switch fix-review to ollama" or edit directly.
 
-provider: openrouter
+provider: ollama
 
 # ---------------------------------------------------------------------------
 # Reviewer models per provider

--- a/.claude/skills/fix-review/config.yaml
+++ b/.claude/skills/fix-review/config.yaml
@@ -29,7 +29,7 @@ reviewers:
     round_2:
       model: minimax-m2.5:cloud                 # MiniMax — RL-trained, 198K ctx
     round_3:
-      model: devstral-2:123b-cloud              # Mistral — codebase explorer, 256K ctx
+      model: mistral-large-3:675b-cloud         # Mistral — codebase explorer, 256K ctx
 
 # ---------------------------------------------------------------------------
 # Arbiter (Round 4)

--- a/.claude/skills/lib/env.sh
+++ b/.claude/skills/lib/env.sh
@@ -1,42 +1,58 @@
 #!/usr/bin/env bash
-# .claude/skills/lib/env.sh
-# Load API keys from .env.local into the calling shell's environment.
-# Usage: . .claude/skills/lib/env.sh   (must be sourced, not executed)
+# lib/env.sh — load named API keys for skill scripts
+#
+# Usage:
+#   source .claude/skills/lib/env.sh
+#
+#   load_env_key OPENROUTER_API_KEY          # auto-search: .env.local → .env → shell env
+#   load_env_key OLLAMA_API_KEY .env.local   # explicit file (no fallback)
+#
+# After load_env_key the variable is exported into the current shell.
+# Strips surrounding quotes and trailing whitespace to prevent invisible auth failures.
+#
+# Search order (no explicit file):
+#   1. .env.local   (gitignored, preferred for secrets)
+#   2. .env         (may be committed — use for non-secret defaults only)
+#   3. Shell environment (already exported by the caller's shell)
 
-# load_env_key KEY
-#   Reads KEY from .env.local (if present) and exports it.
-#   Produces a clear error and returns 1 if the key is missing.
 load_env_key() {
   local key="$1"
+  local explicit_file="${2:-}"
 
-  # Reject key names that would make the grep pattern unsafe.
-  if [[ ! "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
-    echo "ERROR: Invalid key name '${key}' — must match [A-Za-z_][A-Za-z0-9_]*" >&2
-    return 1
+  _lvk_extract() {
+    local k="$1" f="$2"
+    grep "^${k}=" "$f" 2>/dev/null \
+      | head -1 \
+      | cut -d= -f2- \
+      | sed 's/^["'"'"']//;s/["'"'"']$//' \
+      | sed 's/[[:space:]]*$//'
+  }
+
+  local value=""
+
+  if [ -n "$explicit_file" ]; then
+    value=$(_lvk_extract "$key" "$explicit_file")
+    if [ -z "$value" ]; then
+      echo "WARNING: ${key} not found in ${explicit_file}" >&2
+      return 1
+    fi
+  else
+    for f in .env.local .env; do
+      [ -f "$f" ] || continue
+      value=$(_lvk_extract "$key" "$f")
+      [ -n "$value" ] && break
+    done
+
+    if [ -z "$value" ]; then
+      # Already exported by the calling shell?
+      value=$(printenv "$key" 2>/dev/null || true)
+    fi
+
+    if [ -z "$value" ]; then
+      echo "WARNING: ${key} not found in .env.local, .env, or shell environment" >&2
+      return 1
+    fi
   fi
 
-  # Already set in environment — nothing to do.
-  if [[ -n "${!key}" ]]; then
-    return 0
-  fi
-
-  local env_file
-  env_file="$(git rev-parse --show-toplevel 2>/dev/null)/.env.local"
-
-  if [[ ! -f "$env_file" ]]; then
-    echo "ERROR: .env.local not found at ${env_file}." >&2
-    echo "       Copy .env.local.example and fill in your keys." >&2
-    return 1
-  fi
-
-  local value
-  value=$(grep -E "^${key}=" "$env_file" | head -1 | cut -d= -f2-)
-
-  if [[ -z "$value" ]]; then
-    echo "ERROR: ${key} is not set in .env.local." >&2
-    echo "       Add ${key}=<your-value> to .env.local." >&2
-    return 1
-  fi
-
-  export "${key}=${value}"
+  export "$key"="$value"
 }

--- a/.claude/skills/lib/env.sh
+++ b/.claude/skills/lib/env.sh
@@ -19,6 +19,11 @@ load_env_key() {
   local key="$1"
   local explicit_file="${2:-}"
 
+  if [[ ! "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+    echo "ERROR: Invalid key name '${key}' — must match [A-Za-z_][A-Za-z0-9_]*" >&2
+    return 1
+  fi
+
   _lvk_extract() {
     local k="$1" f="$2"
     grep "^${k}=" "$f" 2>/dev/null \

--- a/.claude/skills/lib/rest.sh
+++ b/.claude/skills/lib/rest.sh
@@ -26,6 +26,19 @@ rest_post() {
   local auth_scheme="${4:-Bearer}"
   local timeout="${REST_TIMEOUT:-120}"
 
+  # Reject plain HTTP for non-loopback hosts to prevent credential exfiltration.
+  if [[ "$url" =~ ^http:// ]] && [[ ! "$url" =~ ^http://(localhost|127\.|\[?::1\]?)([:/]|$) ]]; then
+    echo "ERROR: refusing plain HTTP for non-loopback host in '${url}'." >&2
+    echo "       Use https:// or a localhost address." >&2
+    return 1
+  fi
+
+  # Auth header values must not contain control characters (CWE-93 header injection).
+  if [[ "$api_key" == *$'\n'* || "$api_key" == *$'\r'* || "$auth_scheme" == *$'\n'* || "$auth_scheme" == *$'\r'* ]]; then
+    echo "ERROR: auth_scheme/api_key contains illegal control characters." >&2
+    return 1
+  fi
+
   # Payload via stdin to avoid ARG_MAX limits on large PR diffs.
   local -a args=(-sS --max-time "$timeout"
     -H "Content-Type: application/json"
@@ -33,7 +46,7 @@ rest_post() {
   [ -n "$api_key" ] && args+=(-H "Authorization: ${auth_scheme} ${api_key}")
 
   local response errfile exit_code
-  errfile=$(mktemp)
+  errfile=$(mktemp) || { echo "ERROR: failed to create temp file for curl stderr" >&2; return 1; }
   response=$(printf '%s' "$payload" | curl "${args[@]}" "$url" 2>"$errfile")
   exit_code=$?
   local curl_err; curl_err=$(cat "$errfile"); rm -f "$errfile"

--- a/.claude/skills/lib/rest.sh
+++ b/.claude/skills/lib/rest.sh
@@ -1,68 +1,169 @@
 #!/usr/bin/env bash
-# .claude/skills/lib/rest.sh
-# Chat completion helpers for OpenRouter and Ollama.
-# Usage: . .claude/skills/lib/rest.sh   (must be sourced, not executed)
+# lib/rest.sh — REST helpers for skill scripts
+#
+# Usage:
+#   source .claude/skills/lib/rest.sh
+#
+#   RESPONSE=$(rest_post "$URL" "$PAYLOAD" "$API_KEY")          # Bearer auth
+#   RESPONSE=$(rest_post "$URL" "$PAYLOAD" "$API_KEY" "Token")  # custom scheme
+#   RESPONSE=$(rest_post "$URL" "$PAYLOAD")                     # no auth (Ollama local)
+#
+# rest_post writes the raw response body to stdout.
+# On connection failure or curl error it writes to stderr and returns exit code 1.
+# HTTP-level errors (4xx/5xx) are returned as-is — callers check .error in the JSON.
+#
+# Set REST_TIMEOUT (seconds, default 120) or REST_OLLAMA_TIMEOUT (default 300)
+# before sourcing to override.
 
-# chat PROVIDER MODEL PAYLOAD_FILE
-#   Sends a chat completion request and prints the full response JSON.
-#   PROVIDER  — "openrouter" or "ollama"
-#   MODEL     — model identifier string
-#   PAYLOAD_FILE — path to a JSON file with the request body
-#   Returns 1 on HTTP / curl error.
-chat() {
-  local provider="$1"
-  local model="$2"
-  local payload_file="$3"
+# ---------------------------------------------------------------------------
+# Core transport
+# ---------------------------------------------------------------------------
 
-  case "$provider" in
-    openrouter)
-      load_env_key OPENROUTER_API_KEY || return 1
-      curl -s --fail-with-body \
-        --connect-timeout 30 --max-time 120 \
-        -X POST "https://openrouter.ai/api/v1/chat/completions" \
-        -H "Authorization: Bearer ${OPENROUTER_API_KEY}" \
-        -H "Content-Type: application/json" \
-        -d "@${payload_file}"
-      ;;
-    ollama)
-      local base="${OLLAMA_BASE_URL:-http://localhost:11434}"
-      # Reject plain HTTP for non-loopback hosts to prevent exfiltration.
-      if [[ "$base" =~ ^http:// ]] && \
-         [[ ! "$base" =~ ^http://(localhost|127\.|::1) ]]; then
-        echo "ERROR: OLLAMA_BASE_URL uses plain HTTP for a non-loopback host." >&2
-        echo "       Use https:// or a localhost address." >&2
-        return 1
-      fi
-      curl -s --fail-with-body \
-        --connect-timeout 30 --max-time 120 \
-        -X POST "${base}/api/chat" \
-        -H "Content-Type: application/json" \
-        -d "@${payload_file}"
-      ;;
-    *)
-      echo "ERROR: Unknown provider '${provider}'. Use 'openrouter' or 'ollama'." >&2
-      return 1
-      ;;
+rest_post() {
+  local url="$1"
+  local payload="$2"
+  local api_key="${3:-}"
+  local auth_scheme="${4:-Bearer}"
+  local timeout="${REST_TIMEOUT:-120}"
+
+  # Payload via stdin to avoid ARG_MAX limits on large PR diffs.
+  local -a args=(-sS --max-time "$timeout"
+    -H "Content-Type: application/json"
+    --data-binary @-)
+  [ -n "$api_key" ] && args+=(-H "Authorization: ${auth_scheme} ${api_key}")
+
+  local response errfile exit_code
+  errfile=$(mktemp)
+  response=$(printf '%s' "$payload" | curl "${args[@]}" "$url" 2>"$errfile")
+  exit_code=$?
+  local curl_err; curl_err=$(cat "$errfile"); rm -f "$errfile"
+
+  if [ $exit_code -ne 0 ]; then
+    echo "ERROR: POST ${url} failed (curl exit ${exit_code}): ${curl_err}" >&2
+    return 1
+  fi
+  printf '%s' "$response"
+}
+
+# Like rest_post but uses REST_OLLAMA_TIMEOUT (default 300s).
+# Use for local/cloud Ollama calls where large models are slow.
+rest_post_ollama() {
+  local timeout="${REST_OLLAMA_TIMEOUT:-300}"
+  REST_TIMEOUT="$timeout" rest_post "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Ollama — /api/chat
+# Response: { "message": { "content": "..." } }
+# ---------------------------------------------------------------------------
+
+ollama_payload() {
+  jq -n --arg model "$1" --arg prompt "$2" \
+    '{model:$model, messages:[{role:"user",content:$prompt}], stream:false}'
+}
+
+# Includes a system role message (Ollama /api/chat supports it).
+ollama_payload_system() {
+  jq -n --arg model "$1" --arg sys "$2" --arg prompt "$3" \
+    '{model:$model, messages:[{role:"system",content:$sys},{role:"user",content:$prompt}], stream:false}'
+}
+
+ollama_content() {
+  printf '%s' "$1" | jq -r '.message.content // empty'
+}
+
+# ---------------------------------------------------------------------------
+# OpenRouter — /api/v1/chat/completions (OpenAI-compatible)
+# Response: { "choices": [{ "message": { "content": "..." } }] }
+# ---------------------------------------------------------------------------
+
+openrouter_payload() {
+  jq -n --arg model "$1" --arg prompt "$2" \
+    '{model:$model, messages:[{role:"user",content:$prompt}], stream:false}'
+}
+
+openrouter_payload_system() {
+  jq -n --arg model "$1" --arg sys "$2" --arg prompt "$3" \
+    '{model:$model, messages:[{role:"system",content:$sys},{role:"user",content:$prompt}], stream:false}'
+}
+
+# Same as openrouter_payload_system but adds reasoning:{exclude:true}.
+# Required for DeepSeek models: without it the <think> chain exhausts max_tokens
+# and the response comes back with content:null and finish_reason:length.
+openrouter_payload_system_no_think() {
+  jq -n --arg model "$1" --arg sys "$2" --arg prompt "$3" \
+    '{model:$model, messages:[{role:"system",content:$sys},{role:"user",content:$prompt}],
+      stream:false, reasoning:{exclude:true}}'
+}
+
+openrouter_content() {
+  printf '%s' "$1" | jq -r '.choices[0].message.content // empty'
+}
+
+# ---------------------------------------------------------------------------
+# Provider-agnostic helpers
+# Use when provider is determined at runtime from config.yaml.
+# PROVIDER values: "openrouter" | "ollama" | anything else → ollama path
+# ---------------------------------------------------------------------------
+
+# Build a user-only chat payload for the given provider.
+# Usage: PAYLOAD=$(chat_payload "$PROVIDER" "$MODEL" "$PROMPT")
+chat_payload() {
+  case "$1" in
+    openrouter) openrouter_payload "$2" "$3" ;;
+    *)          ollama_payload     "$2" "$3" ;;
   esac
 }
 
-# chat_content PROVIDER MODEL PAYLOAD_FILE
-#   Like chat(), but returns only the message content string
-#   (choices[0].message.content for OpenRouter; message.content for Ollama).
-chat_content() {
-  local provider="$1"
-  local model="$2"
-  local payload_file="$3"
-
-  local response
-  response=$(chat "$provider" "$model" "$payload_file") || return 1
-
-  case "$provider" in
-    openrouter)
-      echo "$response" | jq -r '.choices[0].message.content'
-      ;;
-    ollama)
-      echo "$response" | jq -r '.message.content'
-      ;;
+# Build a payload with system + user messages for the given provider.
+# Usage: PAYLOAD=$(chat_payload_system "$PROVIDER" "$MODEL" "$SYSTEM" "$PROMPT")
+chat_payload_system() {
+  case "$1" in
+    openrouter) openrouter_payload_system "$2" "$3" "$4" ;;
+    *)          ollama_payload_system     "$2" "$3" "$4" ;;
   esac
+}
+
+# Like chat_payload_system but suppresses reasoning tokens on thinking models.
+# Use for DeepSeek-family models on OpenRouter; no-op on Ollama.
+chat_payload_system_no_think() {
+  case "$1" in
+    openrouter) openrouter_payload_system_no_think "$2" "$3" "$4" ;;
+    *)          ollama_payload_system              "$2" "$3" "$4" ;;
+  esac
+}
+
+# Extract assistant content from a raw API response.
+# Usage: CONTENT=$(chat_content "$PROVIDER" "$RESPONSE")
+chat_content() {
+  case "$1" in
+    openrouter) openrouter_content "$2" ;;
+    *)          ollama_content     "$2" ;;
+  esac
+}
+
+# Extract token counts from a response.
+# Returns "PROMPT_TOKENS COMPLETION_TOKENS" (space-separated).
+# Ollama responses return "null null" (no token data in /api/chat).
+# Usage: read pt ct < <(chat_tokens "$PROVIDER" "$RESPONSE")
+chat_tokens() {
+  if [ "$1" = "openrouter" ]; then
+    local p c
+    p=$(printf '%s' "$2" | jq -r '.usage.prompt_tokens     // empty' 2>/dev/null)
+    c=$(printf '%s' "$2" | jq -r '.usage.completion_tokens // empty' 2>/dev/null)
+    printf '%s %s' "${p:-null}" "${c:-null}"
+  else
+    printf 'null null'
+  fi
+}
+
+# Convenience: POST + extract content in a single call.
+# Usage: CONTENT=$(chat_ask "$PROVIDER" "$URL" "$KEY" "$MODEL" "$SYSTEM" "$PROMPT")
+# Use chat_payload_system_no_think variant when models are DeepSeek-family.
+chat_ask() {
+  local provider="$1" url="$2" key="$3" model="$4" sys="$5" prompt="$6"
+  local payload response
+  payload=$(chat_payload_system "$provider" "$model" "$sys" "$prompt")
+  response=$(rest_post "$url" "$payload" "$key")
+  chat_content "$provider" "$response"
 }

--- a/.claude/skills/lib/rest.sh
+++ b/.claude/skills/lib/rest.sh
@@ -27,7 +27,7 @@ rest_post() {
   local timeout="${REST_TIMEOUT:-120}"
 
   # Reject plain HTTP for non-loopback hosts to prevent credential exfiltration.
-  if [[ "$url" =~ ^http:// ]] && [[ ! "$url" =~ ^http://(localhost|127\.|\[?::1\]?)([:/]|$) ]]; then
+  if [[ "$url" =~ ^http:// ]] && [[ ! "$url" =~ ^http://(localhost|127\.|::1) ]]; then
     echo "ERROR: refusing plain HTTP for non-loopback host in '${url}'." >&2
     echo "       Use https:// or a localhost address." >&2
     return 1


### PR DESCRIPTION
## Summary
- Ollama is retiring `devstral-2:123b` on 2026-07-15 — swap `.claude/skills/fix-review/config.yaml` `reviewers.ollama.round_3` to `mistral-large-3:675b-cloud` (tag confirmed live via ollama.com/library)
- Rework `lib/env.sh` (`load_env_key` supports explicit file arg + multi-file search order) and `lib/rest.sh` (generic `rest_post`/`rest_post_ollama` REST helpers replacing the old provider-specific `chat` function)
- `SKILL.md`: switch review-round diff commands from `git diff $(git merge-base ...)` to `gh pr diff "${PR_NUMBER}"` for reliability

## Test plan
- [ ] Run `/fix-review` on this PR to confirm the new ollama fallback model responds correctly (only exercised if provider is switched to `ollama`; primary provider is `openrouter` so this is a fallback-path change)
- [ ] Confirm `env.sh`/`rest.sh` changes don't break existing fix-review invocations