### PR TITLE
chore: track e2e/.gitignore

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+test-results/
+playwright-report/
+.auth/


### PR DESCRIPTION
## Summary
- `e2e/.gitignore` (Playwright test artifacts: node_modules, test-results, playwright-report, .auth) was never tracked — hidden by the global dotfile-ignore blanket rule until that was disabled

## Test plan
- [ ] Confirm `git status` no longer shows it as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)