### PR TITLE
chore(fix-review): retire minimax-m2.5 / kimi-k2.5 on Ollama Cloud

### DIFF
--- a/.claude/skills/fix-review/config.yaml
+++ b/.claude/skills/fix-review/config.yaml
@@ -25,9 +25,9 @@ reviewers:
 
   ollama:
     round_1:
-      model: kimi-k2.5:cloud                    # Moonshot AI — strong architecture + 128K ctx
+      model: kimi-k2.6:cloud                    # Moonshot AI — strong architecture + 128K ctx
     round_2:
-      model: minimax-m2.5:cloud                 # MiniMax — RL-trained, 198K ctx
+      model: minimax-m2.7:cloud                 # MiniMax — RL-trained, 198K ctx
     round_3:
       model: mistral-large-3:675b-cloud         # Mistral — codebase explorer, 256K ctx
 


### PR DESCRIPTION
## Summary
- Ollama is retiring `minimax-m2.5` and `kimi-k2.5` cloud models on 2026-07-31. Updates the live `fix-review` skill config (`ollama` provider block, rounds 1-2) to the recommended replacements: `kimi-k2.6`, `minimax-m2.7`.

## Test plan
- [x] YAML structure unchanged, only model strings replaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)